### PR TITLE
bit.ly / j.mp as URL shortener

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,16 @@
+2011-01-11  Lars Gregori  <github+twittering-mode@mail.beidfarbig.de>
+
+	* twittering-mode.el: Added j.mp URL shortening service. (Same
+	as bit.ly).
+	(twittering-tinyurl-service): Added 'jmp as service.
+	(twittering-tinyurl-services-map): Added jmp API.
+
 2011-01-08  Lars Gregori  <github+twittering-mode@mail.beidfarbig.de>
 
 	* twittering-mode.el: Added bit.ly URL shortening service.
 	An account with a login and API key is necessary. The API key
 	can be set on http://bit.ly/a/account page.
-	(twittering-tinyurl-service): Added 'tinyurl as service.
+	(twittering-tinyurl-service): Added 'bitly as service.
 	(twittering-bitly-login): The bit.ly login name.
 	(twittering-bitly-api-key): The bit.ly API key.
 	(twittering-tinyurl-services-map): Is now a function to use

--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -119,19 +119,21 @@ on authorization via OAuth.")
 The upper limit is `twittering-max-number-of-tweets-on-retrieval'.")
 
 (defvar twittering-tinyurl-service 'tinyurl
-  "The service to use. One of 'tinyurl', 'toly' or 'bitly'.")
+  "The service to use. One of 'tinyurl', 'toly', 'bitly', or 'jmp'.")
 
 (defvar twittering-bitly-login nil
-  "The bit.ly login name.")
+  "The bit.ly or j.mp login name. Note: j.mp is a bit.ly service.")
 
 (defvar twittering-bitly-api-key nil
-  "The bit.ly API key. You can find the API key at http://bit.ly/a/account on your account settings.")
+  "The bit.ly or j.mp API key. You can find the API key at http://bit.ly/a/account on your account settings.")
 
 (defun twittering-tinyurl-services-map ()
   "Alist of tinyfy services."
   `((tinyurl "http://tinyurl.com/api-create.php?url=")
     (toly    "http://to.ly/api.php?longurl=")
     (bitly   "http://api.bit.ly/v3/shorten?login=" ,twittering-bitly-login 
+	     "&apiKey=" ,twittering-bitly-api-key "&format=txt&longUrl=")
+    (jmp     "http://api.j.mp/v3/shorten?login=" ,twittering-bitly-login 
 	     "&apiKey=" ,twittering-bitly-api-key "&format=txt&longUrl=")))
 
 (defvar twittering-mode-map (make-sparse-keymap))


### PR DESCRIPTION
I've added bit.ly and j.mp (which uses the same API as bit.ly) as URL shortener and added two vars for username and API key.
