### PR TITLE
New TinyURL service added

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -158,6 +158,7 @@ To use 'bit.ly or 'j.mp, you have to configure `twittering-bitly-login' and
 			   reply)
 	 (match-string 1 reply))))
     (is.gd . "http://is.gd/create.php?format=simple&url=")
+    (migre.me . "http://migre.me/api.txt?url=")
     (j.mp twittering-make-http-request-for-bitly
 	  (lambda (service reply)
 	    (if (string-match "\n\\'" reply)


### PR DESCRIPTION
Added support for migre.me (Brazilian TinyURL service). Used the simple option
(no XML or JSON)
