### PR TITLE
set "mode-class" property of twittering mode to "special"

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -9769,6 +9769,8 @@ been initialized yet."
     (when (twittering-account-authorized-p)
       (mapc 'twittering-visit-timeline (cdr timeline-spec-list)))))
 
+(put 'twittering-mode 'mode-class 'special)
+
 ;;;;
 ;;;; Preparation for invoking APIs
 ;;;;


### PR DESCRIPTION
from http://www.gnu.org/software/emacs/manual/html_node/elisp/Major-Mode-Conventions.html :

> If mode is appropriate only for specially-prepared text produced by the mode itself (rather than by the user typing at the keyboard or by an external file), then the major mode command symbol should have a property named mode-class with value special.
