### PR TITLE
Switch to *twitter* buffer before launching

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -11824,6 +11824,7 @@ Note that the current implementation assumes `revive.el' 2.19 ."
 (defun twit ()
   "Start twittering-mode."
   (interactive)
+  (switch-to-buffer (get-buffer-create "*twittering*"))
   (twittering-mode))
 
 ;; Local Variables:


### PR DESCRIPTION
Stops twittering-mode from clearing the current buffer - which in some cases means losing data.
