### PR TITLE
Bind "?" to describe-mode in keymap.

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -9932,6 +9932,7 @@ If FORCE is non-nil, all active buffers are updated forcibly."
       (define-key km (kbd "C-c C-p") 'twittering-toggle-proxy)
       (define-key km (kbd "q") 'twittering-kill-buffer)
       (define-key km (kbd "C-c C-q") 'twittering-search)
+      (define-key km (kbd "?") 'describe-mode)
       nil))
 
 (let ((km twittering-mode-menu-on-uri-map))


### PR DESCRIPTION
A lot of modes (Magit, Org, for its speed commands, mu4e) bind "?" to describe-mode or something like it, so that you can see what keys do what. I did this right away when I started using twittering-mode, and I'm sure others would like it, too.
