### PR TITLE
C-c C-n for mentions; configable api host; http2 if using curl

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -2094,7 +2094,7 @@ The alist consists of pairs of field-name and field-value, such as
 	 (status-line (car lines))
 	 (header-lines (cdr lines)))
     (when (string-match
-	   "^\\(HTTP/1\.[01]\\) \\([0-9][0-9][0-9]\\) \\(.*\\)$"
+	   "^\\(HTTP/[12]\.[01]\\) \\([0-9][0-9][0-9]\\)\\(.*\\)$"
 	   status-line)
       (append `((status-line . ,status-line)
 		(http-version . ,(match-string 1 status-line))
@@ -2520,7 +2520,7 @@ The method to perform the request is determined from
 	    ;; http://www.escafrace.co.jp/blog/09/10/16/1008
 	    ("Expect" . "")))
 	 (curl-args
-	  `("--include" "--silent" "--compressed"
+	  `("--include" "--silent" "--compressed" "--http2"
 	    ,@(apply 'append
 		     (mapcar
 		      (lambda (pair)
@@ -2571,10 +2571,10 @@ The method to perform the request is determined from
 	  (goto-char (point-min))
 	  (let ((first-regexp
 		 ;; successful HTTP response
-		 "\\`HTTP/1\.[01] 2[0-9][0-9] .*?\r?\n")
+		 "\\`HTTP/[12]\.[01] 2[0-9][0-9].*?\r?\n")
 		(next-regexp
 		 ;; following HTTP response
-		 "^\\(\r?\n\\)HTTP/1\.[01] [0-9][0-9][0-9] .*?\r?\n"))
+		 "^\\(\r?\n\\)HTTP/[12]\.[01] [0-9][0-9][0-9].*?\r?\n"))
 	    (when (and (search-forward-regexp first-regexp nil t)
 		       (search-forward-regexp next-regexp nil t))
 	      (let ((beg (point-min))
@@ -3621,7 +3621,7 @@ function."
   (with-current-buffer buffer
     (goto-char (point-min))
     (when (search-forward-regexp
-	   "\\`\\(\\(HTTP/1\.[01]\\) \\([0-9][0-9][0-9]\\) \\(.*?\\)\\)\r?\n"
+	   "\\`\\(\\(HTTP/[12]\.[01]\\) \\([0-9][0-9][0-9]\\)\\(.*?\\)\\)\r?\n"
 	   nil t)
       (let ((status-line (match-string 1))
 	    (http-version (match-string 2))

--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -10369,6 +10369,7 @@ If FORCE is non-nil, all active buffers are updated forcibly."
     (let ((km twittering-mode-map))
       (define-key km (kbd "C-c C-f") 'twittering-friends-timeline)
       (define-key km (kbd "C-c C-r") 'twittering-replies-timeline)
+      (define-key km (kbd "C-c C-n") 'twittering-mentions-timeline)
       (define-key km (kbd "C-c C-u") 'twittering-user-timeline)
       (define-key km (kbd "C-c C-d") 'twittering-direct-messages-timeline)
       (define-key km (kbd "C-c C-s") 'twittering-update-status-interactive)
@@ -10436,6 +10437,7 @@ If FORCE is non-nil, all active buffers are updated forcibly."
   (let ((important-commands
 	 '(("Timeline" . twittering-friends-timeline)
 	   ("Replies" . twittering-replies-timeline)
+	   ("Mentions" . twittering-mentions-timeline)
 	   ("Update status" . twittering-update-status-interactive)
 	   ("Next" . twittering-goto-next-status)
 	   ("Prev" . twittering-goto-previous-status))))
@@ -11487,6 +11489,10 @@ Pairs of a key symbol and an associated value are following:
 (defun twittering-replies-timeline ()
   (interactive)
   (twittering-visit-timeline '(replies)))
+
+(defun twittering-mentions-timeline ()
+  (interactive)
+  (twittering-visit-timeline '(mentions)))
 
 (defun twittering-public-timeline ()
   (interactive)

--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -6376,7 +6376,7 @@ get-service-configuration -- Get the configuration of the server.
 	    (cond
 	     ((eq spec-type 'user)
 	      (let ((username (elt spec 1)))
-		`("api.twitter.com"
+		`(,twittering-api-host
 		  "1.1/statuses/user_timeline"
 		  ("count" . ,number-str)
 		  ("include_entities" . "true")
@@ -6388,7 +6388,7 @@ get-service-configuration -- Get the configuration of the server.
 	     ((eq spec-type 'list)
 	      (let ((username (elt spec 1))
 		    (list-name (elt spec 2)))
-		`("api.twitter.com"
+		`(,twittering-api-host
 		  "1.1/lists/statuses"
 		  ("count" . ,number-str)
 		  ("include_entities" . "true")
@@ -6398,14 +6398,14 @@ get-service-configuration -- Get the configuration of the server.
 		  ,@(when since_id `(("since_id" . ,since_id)))
 		  ("slug" . ,list-name))))
 	     ((eq spec-type 'direct_messages)
-	      `("api.twitter.com"
+	      `(,twittering-api-host
 		"1.1/direct_messages"
 		("count" . ,number-str)
 		("include_entities" . "true")
 		,@(when max_id `(("max_id" . ,max_id)))
 		,@(when since_id `(("since_id" . ,since_id)))))
 	     ((eq spec-type 'direct_messages_sent)
-	      `("api.twitter.com"
+	      `(,twittering-api-host
 		"1.1/direct_messages/sent"
 		("count" . ,number-str)
 		("include_entities" . "true")
@@ -6413,7 +6413,7 @@ get-service-configuration -- Get the configuration of the server.
 		,@(when since_id `(("since_id" . ,since_id)))))
 	     ((eq spec-type 'favorites)
 	      (let ((user (elt spec 1)))
-		`("api.twitter.com"
+		`(,twittering-api-host
 		  "1.1/favorites/list"
 		  ("count" . ,number-str)
 		  ("include_entities" . "true")
@@ -6421,14 +6421,14 @@ get-service-configuration -- Get the configuration of the server.
 		  ,@(when user `(("screen_name" . ,user)))
 		  ,@(when since_id `(("since_id" . ,since_id))))))
 	     ((eq spec-type 'home)
-	      `("api.twitter.com"
+	      `(,twittering-api-host
 		"1.1/statuses/home_timeline"
 		("count" . ,number-str)
 		("include_entities" . "true")
 		,@(when max_id `(("max_id" . ,max_id)))
 		,@(when since_id `(("since_id" . ,since_id)))))
 	     ((eq spec-type 'mentions)
-	      `("api.twitter.com"
+	      `(,twittering-api-host
 		"1.1/statuses/mentions_timeline"
 		("count" . ,number-str)
 		("include_entities" . "true")
@@ -6448,7 +6448,7 @@ get-service-configuration -- Get the configuration of the server.
 	       spec)
 	      nil)
 	     ((eq spec-type 'retweets_of_me)
-	      `("api.twitter.com"
+	      `(,twittering-api-host
 		"1.1/statuses/retweets_of_me"
 		("count" . ,number-str)
 		("include_entities" . "true")
@@ -6456,13 +6456,13 @@ get-service-configuration -- Get the configuration of the server.
 		,@(when since_id `(("since_id" . ,since_id)))))
 	     ((eq spec-type 'single)
 	      (let ((id (elt spec 1)))
-		`("api.twitter.com"
+		`(,twittering-api-host
 		  "1.1/statuses/show"
 		  ("id" . ,id)
 		  ("include_entities" . "true"))))
 	     ((eq spec-type 'search)
 	      (let ((word (elt spec 1)))
-		`("api.twitter.com"
+		`(,twittering-api-host
 		  "1.1/search/tweets"
 		  ("count" . ,number-str)
 		  ("include_entities" . "true")
@@ -6534,7 +6534,7 @@ get-service-configuration -- Get the configuration of the server.
     ;; Get list names.
     (let* ((username (cdr (assq 'username args-alist)))
 	   (sentinel (cdr (assq 'sentinel args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/lists/list")
 	   (http-parameters `(("screen_name" . ,username)))
 	   (format-str "json")
@@ -6545,7 +6545,7 @@ get-service-configuration -- Get the configuration of the server.
    ((eq command 'get-list-subscriptions)
     (let* ((username (cdr (assq 'username args-alist)))
 	   (sentinel (cdr (assq 'sentinel args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/lists/subscriptions")
 	   (http-parameters
 	    `(("count" . "20")
@@ -6558,7 +6558,7 @@ get-service-configuration -- Get the configuration of the server.
    ((eq command 'create-friendships)
     ;; Create a friendship.
     (let* ((username (cdr (assq 'username args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/friendships/create")
 	   (http-parameters
 	    `(("screen_name" . ,username)))
@@ -6568,7 +6568,7 @@ get-service-configuration -- Get the configuration of the server.
    ((eq command 'destroy-friendships)
     ;; Destroy a friendship
     (let* ((username (cdr (assq 'username args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/friendships/destroy")
 	   (http-parameters
 	    `(("screen_name" . ,username)))
@@ -6578,7 +6578,7 @@ get-service-configuration -- Get the configuration of the server.
    ((eq command 'create-favorites)
     ;; Create a favorite.
     (let* ((id (cdr (assq 'id args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/favorites/create")
 	   (http-parameters `(("id" . ,id)))
 	   (format-str "json"))
@@ -6587,7 +6587,7 @@ get-service-configuration -- Get the configuration of the server.
    ((eq command 'destroy-favorites)
     ;; Destroy a favorite.
     (let* ((id (cdr (assq 'id args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/favorites/destroy")
 	   (http-parameters `(("id" . ,id)))
 	   (format-str "json"))
@@ -6597,7 +6597,7 @@ get-service-configuration -- Get the configuration of the server.
     ;; Post a tweet.
     (let* ((status (cdr (assq 'status args-alist)))
 	   (id (cdr (assq 'in-reply-to-status-id args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/statuses/update")
 	   (http-parameters
 	    `(("status" . ,status)
@@ -6608,7 +6608,7 @@ get-service-configuration -- Get the configuration of the server.
    ((eq command 'destroy-status)
     ;; Destroy a status.
     (let* ((id (cdr (assq 'id args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method (format "1.1/statuses/destroy/%s" id))
 	   (http-parameters nil)
 	   (format-str "json"))
@@ -6618,7 +6618,7 @@ get-service-configuration -- Get the configuration of the server.
    ((eq command 'retweet)
     ;; Post a retweet.
     (let* ((id (cdr (assq 'id args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method (format "1.1/statuses/retweet/%s" id))
 	   (http-parameters nil)
 	   (format-str "json"))
@@ -6626,7 +6626,7 @@ get-service-configuration -- Get the configuration of the server.
 			    format-str additional-info)))
    ((eq command 'verify-credentials)
     ;; Verify the account.
-    (let* ((host "api.twitter.com")
+    (let* ((host twittering-api-host)
 	   (method "1.1/account/verify_credentials")
 	   (http-parameters nil)
 	   (format-str "json")
@@ -6637,7 +6637,7 @@ get-service-configuration -- Get the configuration of the server.
 			   sentinel clean-up-sentinel)))
    ((eq command 'send-direct-message)
     ;; Send a direct message.
-    (let* ((host "api.twitter.com")
+    (let* ((host twittering-api-host)
 	   (method "1.1/direct_messages/new")
 	   (http-parameters
 	    `(("screen_name" . ,(cdr (assq 'username args-alist)))
@@ -6649,7 +6649,7 @@ get-service-configuration -- Get the configuration of the server.
     ;; Mute a user.
     (let* ((user-id (cdr (assq 'user-id args-alist)))
 	   (username (cdr (assq 'username args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method
 	    (cdr (assq command '((mute . "1.1/mutes/users/create")
 				 (unmute . "1.1/mutes/users/destroy")))))
@@ -6663,7 +6663,7 @@ get-service-configuration -- Get the configuration of the server.
     ;; Block a user.
     (let* ((user-id (cdr (assq 'user-id args-alist)))
 	   (username (cdr (assq 'username args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/blocks/create")
 	   (http-parameters (if user-id
 				`(("user_id" . ,user-id))
@@ -6675,7 +6675,7 @@ get-service-configuration -- Get the configuration of the server.
     ;; Report a user as a spammer and block him or her.
     (let* ((user-id (cdr (assq 'user-id args-alist)))
 	   (username (cdr (assq 'username args-alist)))
-	   (host "api.twitter.com")
+	   (host twittering-api-host)
 	   (method "1.1/users/report_spam")
 	   (http-parameters (if user-id
 				`(("user_id" . ,user-id))
@@ -6684,7 +6684,7 @@ get-service-configuration -- Get the configuration of the server.
       (twittering-http-post account-info-alist host method http-parameters
 			    format-str additional-info)))
    ((eq command 'get-service-configuration)
-    (let* ((host "api.twitter.com")
+    (let* ((host twittering-api-host)
 	   (method "1.1/help/configuration")
 	   (http-parameters nil)
 	   (format-str "json")


### PR DESCRIPTION
1. add C-c C-n to visit mentions timeline, which is similar to replies. may help https://github.com/hayamiz/twittering-mode/issues/70
2. let twittering-api-host do work if set in config, especially useful with third-part api
3. test and try using http2 (by adding `--http2`) with curl if supported. (also change some regexp for work but needs review).
