### PR TITLE
twittering-edit-skeleton: default to inherit-mentions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,10 @@
   variable as "%i %s,  %@:\n%FILL[  ]{%T // from %f%L%r%R}\n ".
 
 ### Improvements
+
+* By default, replies now inherit mentions.  This can be changed by
+  customizing the `twittering-edit-skeleton' custom variable.
+
 * Embedding all VeriSign Root CA Certificates.
   All active root CA certificates available at
   https://www.symantec.com/page.jsp?id=roots
@@ -33,7 +37,7 @@
   quoted tweet. The quoted tweet is rendered with the format string in
   the braces. For example, "%QT{%s}" means the author of the quoted
   tweet. The specifier is rendered only when the tweet quotes another
-  tweet. 
+  tweet.
   You can see the quoted tweet itself by executing
   `twittering-other-user-timeline' (which is bound to "v" in default)
   on the timestamp of the quoted tweet.

--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -10716,7 +10716,7 @@ recipient."
   :group 'twittering-mode
   :type 'alist)
 
-(defcustom twittering-edit-skeleton 'none
+(defcustom twittering-edit-skeleton 'inherit-mentions
   "*A symbol specifying an effective skeleton.
 
 The list of valid value is defined in `twittering-edit-skeleton-alist'.


### PR DESCRIPTION
I.e., in a reply by @\wendy to

> @\wendy @\salem hello

sent by @\tomas, the initial string in the reply popup should be

> @\tomas @\salem

This is the default behavior of all other Twitter clients that I'm
aware of.