### PR TITLE
Fix the regex of content-type in order to accept ANSI color code

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -2054,7 +2054,7 @@ The alist consists of pairs of field-name and field-value, such as
 	    (mapcar (lambda (entry)
 		      (when (and (stringp (car entry))
 				 (let ((case-fold-search t))
-				   (string-match "\\`content-type\\'"
+				   (string-match "\\`\\(\\\033\\[[0-9]*m\\)*content-type\\(\\\033\\[[0-9]*m\\)*\\'"
 						 (car entry))))
 			(cdr entry)))
 		    header-info))))


### PR DESCRIPTION
Since curl version 7.61.0, the keys of response header are show bold, in other words, response header contains ANSI color code [1].
For example, `\x1b[1mcontent-type\x1b[21m` instead of `content-type`.

This PR fixes regex for detection of content-type, and resolves #148 .

[1] https://curl.haxx.se/changes.html