### PR TITLE
ISSUE #154: Fix differences in naming functions of epa.el in emacs

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -86,6 +86,11 @@
 			 (list str)))
 		     process-environment)))))
       ad-do-it)))
+
+(when (>= 27 emacs-major-version)
+  ;;  Cheap support newest version of emacs plus backward compatibility
+  (defalias 'epa--decode-coding-string 'decode-coding-string))
+
 (require 'url)
 
 (defgroup twittering-mode nil


### PR DESCRIPTION
* twittering-mode.el: In Emacs version 27 function
`(epa--decode-coding-string)` was renamed to `(decode-coding-string)`
and it causes the error on a snapshot version of Emacs.
[Proof](
http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=21ab346a07eff8ba43cb2738dc6752f012b77670)