### PR TITLE
Use parsable version string

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -11,7 +11,7 @@
 ;;	Alberto Garcia <agarcia@igalia.com>
 ;;	Xavier Maillard <xavier@maillard.im>
 ;; Created: Sep 4, 2007
-;; Version: HEAD
+;; Version: 3.0.0-snapshot
 ;; Identity: $Id$
 ;; Keywords: twitter web
 ;; URL: http://twmode.sf.net/


### PR DESCRIPTION
Currently, your package warning from package-lint.
``` emacs-lisp
 twitteri…    14  13 warning         "head" is not a valid version. MELPA will handle this, but other archives will not. (emacs-lisp-package)
```

And see below snippet.

``` emacs-lisp
(version-to-list "3.0.0")
;;=> (3 0 0)


(version-to-list "HEAD")
;;=> (error "Invalid version syntax: ‘HEAD’ (must start with a number)")


(version-to-list "3.0.0-snapshot")
;;=> (3 0 0 -4)
```

So, `3.0.0-snapshot` is parsable and reasonable version name.
If you think `3.0.0` is better, I fix it.