### PR TITLE
Add supported Emacs 25, 26

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,7 +33,7 @@ Twittering-mode enables you to twit on Emacsen.
 -------------------
 
 - GNU Emacs 21 (some restrictions)
-- GNU Emacs 22, 23, 24
+- GNU Emacs 22, 23, 24, 25, 26
 
  Prerequisites
 -------------------


### PR DESCRIPTION
Hi!
Currently, Emacs 25 and 26 seems like unsupported in README.
I fix it.  This package works well on Emacs25 and 26, doesn't it?